### PR TITLE
Remove forced min width of input field

### DIFF
--- a/dist/token-autocomplete.css
+++ b/dist/token-autocomplete.css
@@ -4,7 +4,6 @@
     flex-wrap: wrap;
     border: 1px solid #E6E6E6;
     background-color: #FFFFFF;
-    min-width: 200px;
 }
 
 .token-autocomplete-container.token-autocomplete-readonly {

--- a/docs/index.html
+++ b/docs/index.html
@@ -29,6 +29,11 @@
             window.CustomEvent = CustomEvent;
         })();
     </script>
+    <style>
+        .token-autocomplete-container {
+            width: 100%;
+        }
+    </style>
 
 </head>
 <body>


### PR DESCRIPTION
### Description

This was done so the inputs on the demo page look and behave better, but it causes errors when used in Bootstrap forms, where we sometimes have smaller fields (that work fine without the min width).

**Before:**

![image](https://github.com/scireum/token-autocomplete/assets/2427877/05a7e9d0-765c-4e56-816d-bfdae83d2179)

**After:**

![image](https://github.com/scireum/token-autocomplete/assets/2427877/dc908647-b25e-45ba-a042-3ed90192bf0d)

### Checklist

- [x] Code change has been tested and works locally
- [x] TSC (TypeScript Compiler) has been run and changes are reflected in the dist folder
